### PR TITLE
Add flags to keep all pass statements and those after docstrings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 *autoflake8* removes unused imports and unused variables from Python code. It
 makes use of [pyflakes](https://pypi.org/project/pyflakes/) to do this.
 
-autoflake8 also removes useless ``pass`` statements.
+autoflake8 also removes useless ``pass`` statements by default.
 
 It's a maintained fork of [autoflake](https://github.com/myint/autoflake).
 
@@ -119,6 +119,10 @@ optional arguments:
                         remove all duplicate keys in objects
   --remove-unused-variables
                         remove unused variables
+  --keep-pass-statements
+                        keep all `pass` statements
+  --keep-pass-after-docstring
+                        keep `pass` statements after a newline ending on """
   --version             show program's version number and exit
   -v, --verbose         print more verbose logs (you can repeat `-v` to make it more verbose)
   --exit-zero-even-if-changed

--- a/autoflake8/cli.py
+++ b/autoflake8/cli.py
@@ -65,6 +65,16 @@ def _main(
         help="remove unused variables",
     )
     parser.add_argument(
+        "--keep-pass-statements",
+        action="store_true",
+        help="keep all pass statements",
+    )
+    parser.add_argument(
+        "--keep-pass-after-docstring",
+        action="store_true",
+        help='keep pass statements after a newline ending on \'"""\'',
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version="%(prog)s " + __version__,

--- a/autoflake8/fix.py
+++ b/autoflake8/fix.py
@@ -474,7 +474,7 @@ def is_literal_or_name(value: bytes) -> bool:
 
 def useless_pass_line_numbers(
     source: bytes,
-    keep_pass_after_docstring=False,
+    keep_pass_after_docstring: bool = False,
 ) -> Iterator[int]:
     """Yield line numbers of unneeded "pass" statements."""
     sio = io.StringIO(source.decode(encoding=detect_source_encoding(source)))
@@ -515,7 +515,7 @@ def useless_pass_line_numbers(
             # Trailing "pass".
             if is_trailing_pass:
                 if keep_pass_after_docstring and is_pass_after_docstring:
-                    pass
+                    continue
                 else:
                     yield start_row
 

--- a/autoflake8/fix.py
+++ b/autoflake8/fix.py
@@ -537,7 +537,7 @@ def filter_useless_pass(
                 useless_pass_line_numbers(
                     source,
                     keep_pass_after_docstring,
-                )
+                ),
             )
         except (SyntaxError, tokenize.TokenError):
             marked_lines = frozenset()

--- a/tests/fix_test.py
+++ b/tests/fix_test.py
@@ -1334,7 +1334,7 @@ def foo():
 
 @abc.abstractmethod
 def bar():
-    \"\"\" 
+    \"\"\"
         Also this is not a useless 'pass'.
     \"\"\"
     pass
@@ -1343,7 +1343,7 @@ def bar():
         filter_useless_pass(
             source,
             keep_pass_after_docstring=True,
-        )
+        ),
     )
 
 


### PR DESCRIPTION
Changes in this PR:

- Add two flags to customize autoflake's behavior for pass statements:
  -  `keep-pass-statements`: allows the user to opt out of the removal of useless pass statements if desired.
  - `keep-pass-after-docstring`: allows the user to keep pass statements after a docstring (see below for caveat).
- Add tests for new flags.
- Update README.

Caveat: since autoflake8 does not use an AST, deciding whether a `pass` statement follows a docstring is not really possible (at least not with a LOT of effort), so the approach is to keep `pass` statements right after a line ending with triple quotes. This is most probably in 99% of the cases a pass after a docstring.

I'm starting a PR in order to gather feedback early, please feel free to suggest any changes or improvements. I love this newer version of autoflake btw! I just need the possibility of keeping pass statements after docstrings which are not useless and is one of the requested features in the original autoflake repo, see [autoflake/issues/73](https://github.com/PyCQA/autoflake/issues/73), [autoflake/issues/10](https://github.com/PyCQA/autoflake/issues/10). I know that autoflake will already keep the pass statement if: 
- I leave an empty line after the docstring, but this goes against [PEP 0257](https://peps.python.org/pep-0257/), 
- or if I use a docstring format which uses `#` instead of triple-quotes, which is not the case for anyone using [Google Style Docstring](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)